### PR TITLE
 Added execution time information for queries

### DIFF
--- a/jaws-hive-sql-rest/src/main/resources/application.conf
+++ b/jaws-hive-sql-rest/src/main/resources/application.conf
@@ -41,6 +41,8 @@ hadoopConf {
   resultsFolder=jawsResultsFolder
   # folder where to write the jobs meta information
   metaInfoFolder=jawsMetainfoFolder
+  # folder where to write the jobs execution time
+  executionTimeFolder=jawsExecutionTimeFolder
   # folder where to write the parquet tables information
   parquetTablesFolder=parquetTablesFolder
 

--- a/jaws-hive-sql-rest/src/main/scala/server/HiveController.scala
+++ b/jaws-hive-sql-rest/src/main/scala/server/HiveController.scala
@@ -119,6 +119,7 @@ object HiveController extends App with SimpleRoutingApp with CORSDirectives {
     configuration.set(Utils.LOGGING_FOLDER, Configuration.loggingFolder.getOrElse("jawsLogs"))
     configuration.set(Utils.STATUS_FOLDER, Configuration.stateFolder.getOrElse("jawsStates"))
     configuration.set(Utils.DETAILS_FOLDER, Configuration.detailsFolder.getOrElse("jawsDetails"))
+    configuration.set(Utils.EXECUTION_TIME_FOLDER, Configuration.executionTimeFolder.getOrElse("jawsExecutionTimeFolder"))
     configuration.set(Utils.METAINFO_FOLDER, Configuration.metaInfoFolder.getOrElse("jawsMetainfoFolder"))
     configuration.set(Utils.RESULTS_FOLDER, Configuration.resultsFolder.getOrElse("jawsResultsFolder"))
     configuration.set(Utils.PARQUET_TABLES_FOLDER, Configuration.parquetTablesFolder.getOrElse("parquetTablesFolder"))
@@ -162,6 +163,7 @@ object Configuration {
   val detailsFolder = getStringConfiguration(hadoopConf, "detailsFolder")
   val resultsFolder = getStringConfiguration(hadoopConf, "resultsFolder")
   val metaInfoFolder = getStringConfiguration(hadoopConf, "metaInfoFolder")
+  val executionTimeFolder = getStringConfiguration(hadoopConf, "executionTimeFolder")
   val namenode = getStringConfiguration(hadoopConf, "namenode")
   val parquetTablesFolder = getStringConfiguration(hadoopConf, "parquetTablesFolder")
 

--- a/jaws-hive-sql-rest/src/test/resources/application.conf
+++ b/jaws-hive-sql-rest/src/test/resources/application.conf
@@ -39,6 +39,8 @@ hadoopConf {
   resultsFolder=jawsResultsFolder
   # folder where to write the jobs meta information
   metaInfoFolder=jawsMetainfoFolder
+  # folder where to write the jobs execution time
+  executionTimeFolder=jawsExecutionTimeFolder
   # folder where to write the parquet tables information
   parquetTablesFolder=parquetTablesFolder
 

--- a/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/DTO/Query.scala
+++ b/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/DTO/Query.scala
@@ -5,9 +5,9 @@ import spray.json.DefaultJsonProtocol._
 /**
  * Created by emaorhian
  */
-case class Query(state: String, queryID: String, query: String, runMetaInfo : QueryMetaInfo)
+case class Query(state: String, queryID: String, query: String, executionTime:Long, runMetaInfo : QueryMetaInfo)
 
 object Query {
-  implicit val logJson = jsonFormat4(apply)
+  implicit val logJson = jsonFormat5(apply)
 
 }

--- a/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/contracts/TJawsLogging.scala
+++ b/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/contracts/TJawsLogging.scala
@@ -16,16 +16,18 @@ trait TJawsLogging {
   def setScriptDetails(queryId: String, scriptDetails: String)
   def addLog(queryId: String, jobId: String, time: Long, log: String)
   def setMetaInfo(queryId: String, metainfo: QueryMetaInfo)
+  def setExecutionTime(queryId:String, executionTime:Long)
 
   def getState(queryId: String): QueryState.QueryState
   def getScriptDetails(queryId: String): String
   def getLogs(queryId: String, time: Long, limit: Int): Logs
   def getMetaInfo(queryId: String): QueryMetaInfo
+  def getExecutionTime(queryId:String):Long
 
   def getQueries(queryId: String, limit: Int): Queries
   def getQueries(queryIds: Seq[String]): Queries = {
     Utils.TryWithRetry {
-      val queryArray = queryIds map (queryID => new Query(getState(queryID).toString, queryID, getScriptDetails(queryID), getMetaInfo(queryID))) toArray
+      val queryArray = queryIds map (queryID => new Query(getState(queryID).toString, queryID, getScriptDetails(queryID), getExecutionTime(queryID), getMetaInfo(queryID))) toArray
       val queries = new Queries(queryArray)
       queries
     }

--- a/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/impl/JawsHdfsLogging.scala
+++ b/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/impl/JawsHdfsLogging.scala
@@ -29,6 +29,7 @@ class JawsHdfsLogging(configuration: Configuration) extends TJawsLogging {
   Utils.createFolderIfDoesntExist(configuration, configuration.get(Utils.STATUS_FOLDER), forcedMode)
   Utils.createFolderIfDoesntExist(configuration, configuration.get(Utils.DETAILS_FOLDER), forcedMode)
   Utils.createFolderIfDoesntExist(configuration, configuration.get(Utils.METAINFO_FOLDER), forcedMode)
+  Utils.createFolderIfDoesntExist(configuration, configuration.get(Utils.EXECUTION_TIME_FOLDER), forcedMode)
 
   override def setState(uuid: String, queryState: QueryState.QueryState) {
 
@@ -149,7 +150,7 @@ class JawsHdfsLogging(configuration: Configuration) extends TJawsLogging {
 
     filesToBeRead.foreach(file => {
       val currentUuid = Utils.getNameFromPath(file)
-      stateList = stateList ++ Array(new Query(Utils.readFile(configuration, folderName + "/" + file), currentUuid, getScriptDetails(currentUuid), getMetaInfo(queryId)))
+      stateList = stateList ++ Array(new Query(Utils.readFile(configuration, folderName + "/" + file), currentUuid, getScriptDetails(currentUuid), getExecutionTime(queryId), getMetaInfo(queryId)))
     })
 
     return new Queries(stateList)
@@ -177,6 +178,27 @@ class JawsHdfsLogging(configuration: Configuration) extends TJawsLogging {
     }
   }
 
+  override def setExecutionTime(queryId: String, executionTime: Long): Unit = {
+    logger.debug(s"Writing execution time $executionTime to query $queryId")
+    Utils.rewriteFile(executionTime.toString, configuration, getExecutionTimeFilePath(queryId))
+  }
+
+  override def getExecutionTime(queryId: String): Long = {
+    logger.debug(s"Reading execution time for for query: $queryId")
+    val filePath = getExecutionTimeFilePath(queryId)
+    if (Utils.checkFileExistence(filePath, configuration)) {
+      val value = Utils.readFile(configuration, getExecutionTimeFilePath(queryId))
+
+      try {
+        value.toLong
+      } catch {
+        case _: Exception => 0
+      }
+    } else {
+      0
+    }
+  }
+
   def deleteQuery(queryId: String) {
     logger.debug(s"Deleting query: $queryId")
 
@@ -186,6 +208,10 @@ class JawsHdfsLogging(configuration: Configuration) extends TJawsLogging {
 
     logger.debug(s"Deleting query details for: $queryId")
     filePath = getQueryDetailsFilePath(queryId)
+    Utils.deleteFile(configuration, filePath)
+
+    logger.debug(s"Deleting execution time for: $queryId")
+    filePath = getExecutionTimeFilePath(queryId)
     Utils.deleteFile(configuration, filePath)
 
     logger.debug(s"Deleting meta info for: $queryId")
@@ -207,6 +233,10 @@ class JawsHdfsLogging(configuration: Configuration) extends TJawsLogging {
 
   def getQueryMetaInfoFilePath(queryId: String): String = {
     configuration.get(Utils.METAINFO_FOLDER) + "/" + queryId
+  }
+
+  def getExecutionTimeFilePath(queryId: String): String = {
+    configuration.get(Utils.EXECUTION_TIME_FOLDER) + "/" + queryId
   }
 
   def getQueryLogsFolderPath(queryId: String): String = {

--- a/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/utils/Utils.scala
+++ b/jaws-spark-sql-data/src/main/scala/com/xpatterns/jaws/data/utils/Utils.scala
@@ -22,6 +22,7 @@ object Utils {
   val FORCED_MODE = "forcedMode"
   val LOGGING_FOLDER = "loggingFolder"
   val STATUS_FOLDER = "stateFolder"
+  val EXECUTION_TIME_FOLDER = "executionTimeFolder"
   val METAINFO_FOLDER = "metaInfoFolder"
   val DETAILS_FOLDER = "detailsFolder"
   val RESULTS_FOLDER = "resultsFolder"

--- a/jaws-spark-sql-data/src/test/resources/application.conf
+++ b/jaws-spark-sql-data/src/test/resources/application.conf
@@ -15,6 +15,8 @@ hadoopConf {
 	resultsFolder=jawsResultsFolder
 	# folder where to write the jobs meta information
 	metaInfoFolder=jawsMetainfoFolder
+	# folder where to write the jobs execution time
+	executionTimeFolder=jawsExecutionTimeFolder
 	# folder where to write the parquet tables information
 	parquetTablesFolder=parquetTablesFolder
 

--- a/jaws-spark-sql-data/src/test/scala/com/xpatterns/jaws/data/impl/JawsLoggingOnHdfsTest.scala
+++ b/jaws-spark-sql-data/src/test/scala/com/xpatterns/jaws/data/impl/JawsLoggingOnHdfsTest.scala
@@ -36,6 +36,7 @@ class JawsLoggingOnHdfsTest extends FunSuite with BeforeAndAfter {
       val stateFolder = Option(hadoopConf.getString("stateFolder"))
       val detailsFolder = Option(hadoopConf.getString("detailsFolder"))
       val resultsFolder = Option(hadoopConf.getString("resultsFolder"))
+      val executionTimeFolder = Option(hadoopConf.getString("executionTimeFolder"))
       val metaInfoFolder = Option(hadoopConf.getString("metaInfoFolder"))
       val namenode = Option(hadoopConf.getString("namenode"))
 
@@ -57,6 +58,7 @@ class JawsLoggingOnHdfsTest extends FunSuite with BeforeAndAfter {
       configuration.set(Utils.STATUS_FOLDER, stateFolder.getOrElse("jawsStates"))
       configuration.set(Utils.DETAILS_FOLDER, detailsFolder.getOrElse("jawsDetails"))
       configuration.set(Utils.METAINFO_FOLDER, metaInfoFolder.getOrElse("jawsMetainfoFolder"))
+      configuration.set(Utils.EXECUTION_TIME_FOLDER, executionTimeFolder.getOrElse("jawsExecutionTimeFolder"))
       configuration.set(Utils.RESULTS_FOLDER, resultsFolder.getOrElse("jawsResultsFolder"))
       logingDal = new JawsHdfsLogging(configuration)
     }

--- a/jaws-spark-sql-data/src/test/scala/com/xpatterns/jaws/data/impl/JawsResultsOnHdfsTest.scala
+++ b/jaws-spark-sql-data/src/test/scala/com/xpatterns/jaws/data/impl/JawsResultsOnHdfsTest.scala
@@ -31,6 +31,7 @@ class JawsResultsOnHdfsTest extends FunSuite with BeforeAndAfter {
       val stateFolder = Option(hadoopConf.getString("stateFolder"))
       val detailsFolder = Option(hadoopConf.getString("detailsFolder"))
       val resultsFolder = Option(hadoopConf.getString("resultsFolder"))
+      val executionTimeFolder = Option(hadoopConf.getString("executionTimeFolder"))
       val metaInfoFolder = Option(hadoopConf.getString("metaInfoFolder"))
       val namenode = Option(hadoopConf.getString("namenode"))
 
@@ -51,6 +52,7 @@ class JawsResultsOnHdfsTest extends FunSuite with BeforeAndAfter {
       configuration.set(Utils.LOGGING_FOLDER, loggingFolder.getOrElse("jawsLogs"))
       configuration.set(Utils.STATUS_FOLDER, stateFolder.getOrElse("jawsStates"))
       configuration.set(Utils.DETAILS_FOLDER, detailsFolder.getOrElse("jawsDetails"))
+      configuration.set(Utils.EXECUTION_TIME_FOLDER, executionTimeFolder.getOrElse("jawsExecutionTimeFolder"))
       configuration.set(Utils.METAINFO_FOLDER, metaInfoFolder.getOrElse("jawsMetainfoFolder"))
       configuration.set(Utils.RESULTS_FOLDER, resultsFolder.getOrElse("jawsResultsFolder"))
       resultsDal = new JawsHdfsResults(configuration)

--- a/jaws-spark-sql-integration-tests/pom.xml
+++ b/jaws-spark-sql-integration-tests/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>com.xpatterns</groupId>
 			<artifactId>jaws-spark-sql-data</artifactId>
-			<version>1.1.0</version>
+			<version>1.1.0-spark1.1.0</version>
 		</dependency>
 	</dependencies>
 

--- a/jaws-spark-sql-rest/src/main/resources/application.conf
+++ b/jaws-spark-sql-rest/src/main/resources/application.conf
@@ -105,6 +105,8 @@ hadoopConf {
 	resultsFolder=jawsResultsFolder
 	# folder where to write the jobs meta information
 	metaInfoFolder=jawsMetainfoFolder
+	# folder where to write the jobs execution time
+	executionTimeFolder=jawsExecutionTimeFolder
 	# folder where to write the parquet tables information
 	parquetTablesFolder=parquetTablesFolder
 }

--- a/jaws-spark-sql-rest/src/main/scala/server/JawsController.scala
+++ b/jaws-spark-sql-rest/src/main/scala/server/JawsController.scala
@@ -643,6 +643,7 @@ object JawsController extends App with SimpleRoutingApp with CORSDirectives {
     configuration.set(Utils.STATUS_FOLDER, Configuration.stateFolder.getOrElse("jawsStates"))
     configuration.set(Utils.DETAILS_FOLDER, Configuration.detailsFolder.getOrElse("jawsDetails"))
     configuration.set(Utils.METAINFO_FOLDER, Configuration.metaInfoFolder.getOrElse("jawsMetainfoFolder"))
+    configuration.set(Utils.EXECUTION_TIME_FOLDER, Configuration.executionTimeFolder.getOrElse("jawsExecutionTimeFolder"))
     configuration.set(Utils.RESULTS_FOLDER, Configuration.resultsFolder.getOrElse("jawsResultsFolder"))
     configuration.set(Utils.PARQUET_TABLES_FOLDER, Configuration.parquetTablesFolder.getOrElse("parquetTablesFolder"))
 
@@ -720,6 +721,7 @@ object Configuration {
   val stateFolder = getStringConfiguration(hadoopConf, "stateFolder")
   val detailsFolder = getStringConfiguration(hadoopConf, "detailsFolder")
   val resultsFolder = getStringConfiguration(hadoopConf, "resultsFolder")
+  val executionTimeFolder = getStringConfiguration(hadoopConf, "executionTimeFolder")
   val metaInfoFolder = getStringConfiguration(hadoopConf, "metaInfoFolder")
   val namenode = getStringConfiguration(hadoopConf, "namenode")
   val parquetTablesFolder = getStringConfiguration(hadoopConf, "parquetTablesFolder")

--- a/jaws-spark-sql-rest/src/test/resources/application.conf
+++ b/jaws-spark-sql-rest/src/test/resources/application.conf
@@ -104,6 +104,8 @@ hadoopConf {
   resultsFolder=jawsResultsFolder
   # folder where to write the jobs meta information
   metaInfoFolder=jawsMetainfoFolder
+  # folder where to write the jobs execution time
+  executionTimeFolder=jawsExecutionTimeFolder
   # folder where to write the parquet tables information
   parquetTablesFolder=parquetTablesFolder
 

--- a/jaws-spark-sql-rest/src/test/scala/api/GetQueryInfoTest.scala
+++ b/jaws-spark-sql-rest/src/test/scala/api/GetQueryInfoTest.scala
@@ -58,7 +58,7 @@ class GetQueryInfoTest extends FunSuite with BeforeAndAfter with ScalaFutures {
     whenReady(f)(s => s match {
       case queries: Queries => {
     	assert(queries.queries.size === 1)
-        assert(queries.queries(0) === new Query("NOT_FOUND", queryId, "", new QueryMetaInfo))
+        assert(queries.queries(0) === new Query("NOT_FOUND", queryId, "", 0, new QueryMetaInfo))
       }
       case _ => fail
     })
@@ -68,16 +68,18 @@ class GetQueryInfoTest extends FunSuite with BeforeAndAfter with ScalaFutures {
 
     val tAct = TestActorRef(new GetQueriesApiActor(dals))
     val queryId = System.currentTimeMillis() + UUID.randomUUID().toString()
+    val executionTime = 100L
     val metaInfo = new QueryMetaInfo(100, 150, 1, true)
     dals.loggingDal.setState(queryId, QueryState.IN_PROGRESS)
     dals.loggingDal.setScriptDetails(queryId, "test script")
+    dals.loggingDal.setExecutionTime(queryId, executionTime)
     dals.loggingDal.setMetaInfo(queryId, metaInfo)
 
     val f = tAct ? GetQueriesMessage(Seq(queryId))
     whenReady(f)(s => s match {
       case queries: Queries => {
     	assert(queries.queries.size === 1)
-        assert(queries.queries(0) === new Query("IN_PROGRESS", queryId, "test script", metaInfo))
+        assert(queries.queries(0) === new Query("IN_PROGRESS", queryId, "test script", executionTime, metaInfo))
       }
       case _ => fail
     })


### PR DESCRIPTION
I added the execution time for the queries that have been executed successfully. This data can be used for benchmarking.